### PR TITLE
feat: build_runner 통합 및 라이브러리 버전 업데이트

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -7,6 +7,9 @@ packages:
 command:
   bootstrap:
     usePubspecOverrides: true
+    hooks:
+      post: |
+        dart run melos build_runner:build
 
 # 공통 라이브러리 버전 관리
 dependencies:
@@ -15,7 +18,7 @@ dependencies:
   riverpod_annotation: ^2.6.1
   
   # Data Modeling
-  freezed_annotation: ^2.4.4
+  freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   
   # Dependency Injection
@@ -24,12 +27,15 @@ dependencies:
   
   # Networking
   dio: ^5.9.0
-  retrofit: ^8.2.1
+  retrofit: ^4.7.1
   web_socket_channel: ^3.0.3
   
   # Database
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+
+  # Logging
+  talker_flutter: ^4.9.3
 
 dev_dependencies:
   # Code Generation
@@ -48,6 +54,12 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 scripts:
+  build_runner:build:
+    run: |
+      dart run \
+      melos exec -c 1 --depends-on="build_runner" -- \
+      "dart run build_runner build --delete-conflicting-outputs"
+
   analyze:
     run: flutter analyze --fatal-infos
     description: Run static analysis on all packages


### PR DESCRIPTION
- melos `bootstrap` 후 `build_runner:build` 스크립트 자동 실행 기능 추가
- `build_runner:build` 스크립트 정의: 의존성 있는 패키지에 대해 `build_runner build` 실행
- 라이브러리 버전 업데이트:
    - `freezed_annotation`: `^2.4.4` -> `^3.1.0`
    - `retrofit`: `^8.2.1` -> `^4.7.1`
- 로깅 라이브러리 `talker_flutter: ^4.9.3` 추가